### PR TITLE
Add CONFLICTS_INSTALL to prevent accidental overrides

### DIFF
--- a/x11-drivers/xlibre-xf86-input-elographics/Makefile
+++ b/x11-drivers/xlibre-xf86-input-elographics/Makefile
@@ -9,6 +9,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-input-elographics
+
 GH_TAGNAME=	80ef66f
 USES=		xlibre-cat:driver
 

--- a/x11-drivers/xlibre-xf86-input-evdev/Makefile
+++ b/x11-drivers/xlibre-xf86-input-evdev/Makefile
@@ -9,6 +9,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT # various styles
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-input-evdev
+
 BUILD_DEPENDS=	${LOCALBASE}/include/linux/input.h:devel/evdev-proto
 LIB_DEPENDS=	libevdev.so:devel/libevdev \
 		libmtdev.so:devel/libmtdev

--- a/x11-drivers/xlibre-xf86-input-joystick/Makefile
+++ b/x11-drivers/xlibre-xf86-input-joystick/Makefile
@@ -9,6 +9,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-input-joystick
+
 GH_TAGNAME=	f6e29f8
 USES=		pathfix xlibre-cat:driver
 

--- a/x11-drivers/xlibre-xf86-input-keyboard/Makefile
+++ b/x11-drivers/xlibre-xf86-input-keyboard/Makefile
@@ -9,6 +9,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-input-keyboard
+
 GH_TAGNAME=	94adc53
 USES=		xlibre-cat:driver
 

--- a/x11-drivers/xlibre-xf86-input-libinput/Makefile
+++ b/x11-drivers/xlibre-xf86-input-libinput/Makefile
@@ -9,6 +9,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT # various styles
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-input-libinput
+
 BUILD_DEPENDS=	${LOCALBASE}/include/linux/input.h:devel/evdev-proto
 LIB_DEPENDS=	libinput.so:x11/libinput
 

--- a/x11-drivers/xlibre-xf86-input-mouse/Makefile
+++ b/x11-drivers/xlibre-xf86-input-mouse/Makefile
@@ -9,6 +9,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-input-mouse
+
 GH_TAGNAME=	6d84baa
 USES=		pathfix xlibre-cat:driver
 

--- a/x11-drivers/xlibre-xf86-input-synaptics/Makefile
+++ b/x11-drivers/xlibre-xf86-input-synaptics/Makefile
@@ -9,6 +9,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-input-synaptics
+
 GH_TAGNAME=	42ac305
 USES=		pathfix xorg xlibre-cat:driver
 USE_XORG=	x11 xtst

--- a/x11-drivers/xlibre-xf86-input-vmmouse/Makefile
+++ b/x11-drivers/xlibre-xf86-input-vmmouse/Makefile
@@ -9,6 +9,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-input-vmmouse
+
 GH_TAGNAME=	f27f2b1
 USES=		gmake xlibre-cat:driver
 

--- a/x11-drivers/xlibre-xf86-input-void/Makefile
+++ b/x11-drivers/xlibre-xf86-input-void/Makefile
@@ -9,6 +9,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-input-void
+
 GH_TAGNAME=	b43e11e
 USES=		xlibre-cat:driver
 

--- a/x11-drivers/xlibre-xf86-input-wacom/Makefile
+++ b/x11-drivers/xlibre-xf86-input-wacom/Makefile
@@ -12,6 +12,8 @@ LICENSE_FILE=	${WRKSRC}/GPL
 BUILD_DEPENDS=	${LOCALBASE}/include/linux/input.h:devel/evdev-proto
 RUN_DEPENDS=	webcamd>=3.1.0.1:multimedia/webcamd
 
+CONFLICTS_INSTALL=	xf86-input-wacom
+
 GH_TAGNAME=	2060426
 USES=		gmake pathfix xorg xlibre-cat:driver
 USE_XORG=	x11 xext xinerama xrandr

--- a/x11-drivers/xlibre-xf86-video-amdgpu/Makefile
+++ b/x11-drivers/xlibre-xf86-video-amdgpu/Makefile
@@ -14,6 +14,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-video-amdgpu
+
 # No amdgpu kernel driver on non-x86 and PC98.
 ONLY_FOR_ARCHS=	aarch64 amd64 i386 powerpc64le
 ONLY_FOR_ARCHS_REASON=	KMS is required and currently only available on x86/arm64/powerpc64le

--- a/x11-drivers/xlibre-xf86-video-ast/Makefile
+++ b/x11-drivers/xlibre-xf86-video-ast/Makefile
@@ -9,6 +9,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-video-ast
+
 GH_TAGNAME=	e86afcc
 USES=		xlibre-cat:driver
 INSTALL_TARGET=	install-strip

--- a/x11-drivers/xlibre-xf86-video-ati/Makefile
+++ b/x11-drivers/xlibre-xf86-video-ati/Makefile
@@ -15,6 +15,8 @@ ONLY_FOR_ARCHS_REASON=	KMS is required and currently only available on x86/arm64
 LIB_DEPENDS=	libpciaccess.so:devel/libpciaccess \
 		libdrm_radeon.so:graphics/libdrm
 
+CONFLICTS_INSTALL=	xf86-video-ati
+
 GH_TAGNAME=	d0ddf97
 USES=		gl xlibre xlibre-cat:driver
 USE_GL=		gl

--- a/x11-drivers/xlibre-xf86-video-dummy/Makefile
+++ b/x11-drivers/xlibre-xf86-video-dummy/Makefile
@@ -9,6 +9,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-video-dummy
+
 GH_TAGNAME=	dd676a9
 USES=		xlibre-cat:driver
 

--- a/x11-drivers/xlibre-xf86-video-intel/Makefile
+++ b/x11-drivers/xlibre-xf86-video-intel/Makefile
@@ -14,6 +14,8 @@ ONLY_FOR_ARCHS_REASON=	only Intel integrated GPUs on x86 are supported
 
 LIB_DEPENDS=	libdrm_intel.so:graphics/libdrm
 
+CONFLICTS_INSTALL=	xf86-video-intel
+
 USES=		localbase xlibre xlibre-cat:driver
 GH_TAGNAME=	5245636
 USE_XORG=	pciaccess pixman

--- a/x11-drivers/xlibre-xf86-video-mga/Makefile
+++ b/x11-drivers/xlibre-xf86-video-mga/Makefile
@@ -9,6 +9,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-video-mga
+
 GH_TAGNAME=	3f2000a
 USES=		gl xlibre-cat:driver
 USE_GL=		gl

--- a/x11-drivers/xlibre-xf86-video-nv/Makefile
+++ b/x11-drivers/xlibre-xf86-video-nv/Makefile
@@ -9,6 +9,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-video-nv
+
 GH_TAGNAME=	ca3f59f
 USES=		tar:xz xlibre-cat:driver
 

--- a/x11-drivers/xlibre-xf86-video-qxl/Makefile
+++ b/x11-drivers/xlibre-xf86-video-qxl/Makefile
@@ -9,6 +9,8 @@ WWW=		https://github.com/X11Libre/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-video-qxl
+
 BUILD_DEPENDS=	${LOCALBASE}/include/linux/input.h:devel/evdev-proto \
 		spice-protocol>=0.12.10:devel/spice-protocol
 LIB_DEPENDS=	libspice-server.so:devel/libspice-server \

--- a/x11-drivers/xlibre-xf86-video-vesa/Makefile
+++ b/x11-drivers/xlibre-xf86-video-vesa/Makefile
@@ -9,6 +9,8 @@ WWW=		https://githhub.com/X11Libre
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+CONFLICTS_INSTALL=	xf86-video-vesa
+
 GH_TAGNAME=	5b33e95
 USES=		xlibre-cat:driver
 

--- a/x11-drivers/xlibre-xf86-video-vmware/Makefile
+++ b/x11-drivers/xlibre-xf86-video-vmware/Makefile
@@ -12,6 +12,8 @@ LICENSE_FILE=	${WRKSRC}/COPYING
 ONLY_FOR_ARCHS=	amd64
 ONLY_FOR_ARCHS_REASON=	vmware gfx protocol is only supported on x86-compatible architectures
 
+CONFLICTS_INSTALL=	xf86-video-vmware
+
 GH_TAGNAME=	90c79a5
 USES=		xlibre-cat:driver
 

--- a/x11-servers/xlibre-server/Makefile
+++ b/x11-servers/xlibre-server/Makefile
@@ -11,6 +11,8 @@ LICENSE=	MIT
 FLAVORS=	xorg xnest xephyr xvfb
 FLAVOR?=	${FLAVORS:[1]}
 
+CONFLICTS_INSTALL=	xorg-server
+
 USES=		compiler:c11 gl meson pkgconfig tar:xz xorg pathfix
 USE_GL=		gl
 


### PR DESCRIPTION
CONFLICTS lines will prevent overriding installed Xorg packages by XLibre overlay port builds. They will inform a sysop to first remove the colliding package, and only them proceed with installing Xlibre equivalent.