### PR TITLE
Poudriere compute error when trying to build xf86-video-scfb@xlibre

### DIFF
--- a/x11-drivers/xf86-input-egalax/Makefile
+++ b/x11-drivers/xf86-input-egalax/Makefile
@@ -11,8 +11,8 @@ LICENSE=	BSD2CLAUSE
 FLAVORS=	xlibre xorg
 FLAVOR?=	${FLAVORS:[1]}
 
-xlibre_PKGNAMEPREFIX=	xlibre-
 .if ${FLAVOR} == xlibre
+PKGNAMEPREFIX=	xlibre-
 USES=		xlibre-cat:driver
 .else
 USES=		xorg-cat:driver

--- a/x11-drivers/xf86-video-scfb/Makefile
+++ b/x11-drivers/xf86-video-scfb/Makefile
@@ -10,8 +10,8 @@ WWW=		https://github.com/rayddteam/xf86-video-scfb
 FLAVORS=	xlibre xorg
 FLAVOR?=	${FLAVORS:[1]}
 
-xlibre_PKGNAMEPREFIX=	xlibre-
 .if ${FLAVOR} == xlibre
+PKGNAMEPREFIX=	xlibre-
 USES=		xlibre-cat:driver
 .else
 USES=		xorg-cat:driver


### PR DESCRIPTION
poudriere would fail to add xf86-video-scfb@xlibre to build queue, stated that the flavor didn't exist.
Changing the FLAVOR?= line fixed this.

Adding the flavor_ prefix to PKGNAMEPREFIX seems to be the preferred way to change the package name, as per the porter's handbook, but I don't think it was needed to fix the issue I was having.