### PR TITLE
Fixed failing builds on poudriere.

### DIFF
--- a/x11-drivers/xf86-input-egalax/Makefile
+++ b/x11-drivers/xf86-input-egalax/Makefile
@@ -8,8 +8,8 @@ COMMENT=	eGalax touch screen input driver for X.Org
 
 LICENSE=	BSD2CLAUSE
 
-FLAVORS=	xorg xlibre
-FLAVOR?=	${FLAVORS:[2]}
+FLAVORS=	xlibre xorg
+FLAVOR?=	${FLAVORS:[1]}
 
 .if ${FLAVOR} == xlibre
 PKGNAMEPREFIX=	xlibre-

--- a/x11-drivers/xf86-video-scfb/Makefile
+++ b/x11-drivers/xf86-video-scfb/Makefile
@@ -7,8 +7,8 @@ MAINTAINER=	x11@FreeBSD.org
 COMMENT=	X.Org syscons display driver
 WWW=		https://github.com/rayddteam/xf86-video-scfb
 
-FLAVORS=	xorg xlibre
-FLAVOR?=	${FLAVORS:[2]}
+FLAVORS=	xlibre xorg
+FLAVOR?=	${FLAVORS:[1]}
 
 .if ${FLAVOR} == xlibre
 PKGNAMEPREFIX=	xlibre-

--- a/x11-drivers/xorgxrdp-devel/Makefile
+++ b/x11-drivers/xorgxrdp-devel/Makefile
@@ -16,8 +16,8 @@ WWW=		https://www.xrdp.org/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-FLAVORS=	xorg xlibre
-FLAVOR?=	${FLAVORS:[2]}
+FLAVORS=	xlibre xorg
+FLAVOR?=	${FLAVORS:[1]}
 
 BUILD_DEPENDS=	nasm:devel/nasm
 RUN_DEPENDS=	xauth:x11/xauth

--- a/x11-drivers/xorgxrdp/Makefile
+++ b/x11-drivers/xorgxrdp/Makefile
@@ -18,8 +18,8 @@ WWW=		https://www.xrdp.org/
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-FLAVORS=	xorg xlibre
-FLAVOR?=	${FLAVORS:[2]}
+FLAVORS=	xlibre xorg
+FLAVOR?=	${FLAVORS:[1]}
 
 BUILD_DEPENDS=	nasm:devel/nasm
 RUN_DEPENDS=	xauth:x11/xauth


### PR DESCRIPTION
Poudiere errored-out while building the flavored versions of xf86-video-scfb and xf86-input-egalax. This seemed to be due to FLAVOR being set to ${FLAVORS:[2]} instead of the more common ${FLAVORS:[1]}. Fixed this by swapping the order of flavors in FLAVORS, and setting FLAVOR to ${FLAVORS:[1]} in these ports.